### PR TITLE
common.sh.in:Alter format of two var-assignments

### DIFF
--- a/common.sh.in
+++ b/common.sh.in
@@ -428,8 +428,8 @@ fi
 : ${SWAP_SIZE:="${INSTANCE_MEM}"}
 : ${BOOT_SIZE:="100"}
 : ${FILESYSTEM:="ext3"}
-: ${KERNEL_ARGS=""}
-: ${OVERLAY=""}
+: ${KERNEL_ARGS:=""}
+: ${OVERLAY:=""}
 : ${IMAGE_NAME:=""}
 : ${IMAGE_TYPE:="dump"}
 : ${NOMOUNT:="no"}


### PR DESCRIPTION
I am new to this package, and as a zsheller my bashism-fu is rusty, so I am not even sure this is a bug. I would have just opened an issue for it, but https://github.com/osuosl/ganeti-instance-image doesn't seem to have the Issues module enabled (for me at least) - only Pull-Requests. The "issue" is below. Of course if those assignments are deliberate and not an issue, it won't hurt my feelings if you close this without extensive explanations...

In [two lines in common.sh.in](https://github.com/osuosl/ganeti-instance-image/blob/master/common.sh.in#L431-L432) two variables are assigned-if-unset by ${foo=bar}, whereas all the others are assigned-if-empty-string ${foo:=bar}. That difference is shown below:

```
unset blah; : ${blah:=burma}; echo "X${blah}X"
 --> XburmaX
unset blah; : ${blah=burma}; echo "X${blah}X"
 --> XburmaX
blah=""; : ${blah:=burma}; echo "X${blah}X"
 --> XburmaX
blah=""; : ${blah=burma}; echo "X${blah}X"
 --> XX
```

Is there a reason KERNEL_ARGS and OVERLAY should only be set if truly unset and not when an empty string? My suspicions are raised because it *may* be part of the cause of another issue I am investigating at the moment...