### PR TITLE
Fix mount-disks & umount-disks for instances with multiple disks

### DIFF
--- a/tools/mount-disks.in
+++ b/tools/mount-disks.in
@@ -16,7 +16,7 @@ OS_API_VERSION="15"
 # do stuff
 output="$(gnt-instance activate-disks $INSTANCE_NAME)"
 
-DISK_0_PATH="${output/*disk\/0\:/}"
+DISK_0_PATH="`printf '%s' "$output" | sed -n -e '/disk\/0:/! b; s/^.*disk\/0://; p'`"
 
 . @osdir@/@osname@/common.sh
 

--- a/tools/umount-disks.in
+++ b/tools/umount-disks.in
@@ -17,7 +17,7 @@ OS_API_VERSION="15"
 # do stuff
 output="$(gnt-instance activate-disks $INSTANCE_NAME)"
 
-DISK_0_PATH="${output/*disk\/0\:/}"
+DISK_0_PATH="`printf '%s' "$output" | sed -n -e '/disk\/0:/! b; s/^.*disk\/0://; p'`"
 filesystem_dev="${DISK_0_PATH/\/dev\//}"
 
 . @osdir@/@osname@/common.sh


### PR DESCRIPTION
When an instance uses more than one disk the present method for getting disk0 fails. This fixes it.