### PR TITLE
Configure serial getty in securetty if present

### DIFF
--- a/common.sh.in
+++ b/common.sh.in
@@ -397,6 +397,9 @@ setup_console() {
             echo "No support for your OS in instance-image, skipping..."
             ;;
     esac
+    if [ -f ${target}/etc/securetty ] && ! grep -q '^ttyS0$' ${target}/etc/securetty; then
+        printf '\n\n# Added by ganeti-instance-image\nttyS0\n' >> ${target}/etc/securetty
+    fi
 }
 
 cleanup() {


### PR DESCRIPTION
Ensure root can login on serial getty, even in the face of secure settings.