### PR TITLE
Add pre-mount hook-handling&partition resize hook

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,9 @@ edit = sed \
 	   -e 's|@KPARTX[@]|$(KPARTX)|g' \
 	   -e 's|@SFDISK[@]|$(SFDISK)|g' \
 	   -e 's|@PARTED[@]|$(PARTED)|g' \
-	   -e 's|@QEMU_IMG[@]|$(QEMU_IMG)|g'
+	   -e 's|@QEMU_IMG[@]|$(QEMU_IMG)|g' \
+	   -e 's|@BLOCKDEV_CMD[@]|$(BLOCKDEV_CMD)|g' \
+	   -e 's|@BLKID[@]|$(BLKID)|g'
 
 common.sh: Makefile
 	rm -f $@ $@.tmp

--- a/common.sh.in
+++ b/common.sh.in
@@ -26,6 +26,8 @@ PARTED="@PARTED@"
 QEMU_IMG="@QEMU_IMG@"
 MKDIR_P="@MKDIR_P@"
 INSTANCE_MEM=
+BLOCKDEV_CMD="@BLOCKDEV_CMD@"
+BLKID="@BLKID@"
 
 CLEANUP=( )
 
@@ -435,6 +437,7 @@ fi
 : ${NOMOUNT:="no"}
 : ${ARCH:=""}
 : ${CUSTOMIZE_DIR:="@sysconfdir@/ganeti/instance-image/hooks"}
+: ${PRE_CUSTOMIZE_DIR:="@sysconfdir@/ganeti/instance-image/pre-hooks"}
 : ${VARIANTS_DIR:="@sysconfdir@/ganeti/instance-image/variants"}
 : ${NETWORKS_DIR:="@sysconfdir@/ganeti/instance-image/networks"}
 : ${OVERLAYS_DIR:="@sysconfdir@/ganeti/instance-image/overlays"}
@@ -446,23 +449,8 @@ fi
 SCRIPT_NAME=$(basename $0)
 KERNEL_PATH="$INSTANCE_HV_kernel_path"
 
-if [ -f /sbin/blkid -a -x /sbin/blkid ]; then
-    VOL_ID="/sbin/blkid -c /dev/null -o value -s UUID"
-    VOL_TYPE="/sbin/blkid -c /dev/null -o value -s TYPE"
-else
-    for dir in /lib/udev /sbin; do
-        if [ -f $dir/vol_id -a -x $dir/vol_id ]; then
-            VOL_ID="$dir/vol_id -u"
-            VOL_TYPE="$dir/vol_id -t"
-        fi
-    done
-fi
-
-if [ -z "$VOL_ID" ]; then
-    log_error "vol_id or blkid not found, please install udev or util-linux"
-    exit 1
-fi
-
+VOL_ID="${BLKID} -c /dev/null -o value -s UUID"
+VOL_TYPE="${BLKID} -c /dev/null -o value -s TYPE"
 
 if [ -z "$OS_API_VERSION" -o "$OS_API_VERSION" = "5" ]; then
   OS_API_VERSION=5

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,16 @@ if test -z "$QEMU_IMG" ; then
   AC_MSG_ERROR([qemu-img not found in $PATH])
 fi
 
+AC_PATH_PROG(BLOCKDEV_CMD, [blockdev], [], [$PATH:/usr/sbin:/sbin])
+if test -z "$BLOCKDEV_CMD" ; then
+  AC_MSG_ERROR([blockdev not found in $PATH])
+fi
+
+AC_PATH_PROG(BLKID, [blkid], [], [$PATH:/usr/sbin:/sbin])
+if test -z "$BLKID" ; then
+  AC_MSG_ERROR([blkid not found in $PATH])
+fi
+
 AC_CONFIG_FILES([
     Makefile
 ])

--- a/create
+++ b/create
@@ -43,7 +43,7 @@ if [ "$CDINSTALL" = "no" ] ; then
       CLEANUP+=("$LOSETUP -d $blockdev")
     fi
 
-    DISK_SIZE="$(expr `blockdev --getsize64 $blockdev` / 1048576)"
+    DISK_SIZE="$(expr `${BLOCKDEV_CMD} --getsize64 $blockdev` / 1048576)"
 
     if [ "${SWAP}" = "yes" ] && [ -z "$SWAP_SIZE" ] ; then
         log_error "SWAP_SIZE not set however SWAP is enabled"
@@ -73,6 +73,14 @@ if [ "$CDINSTALL" = "no" ] ; then
     if [ "${NOMOUNT}" = "yes" ] ; then
       cleanup
       exit 0
+    fi
+
+    RUN_PARTS=`which run-parts`
+
+    if [ -n "$RUN_PARTS" -a -n "$PRE_CUSTOMIZE_DIR" -a -d "$PRE_CUSTOMIZE_DIR" ]; then
+        BLOCKDEV=$blockdev
+        export TARGET SUITE BLOCKDEV IMAGE_TYPE
+        $RUN_PARTS $PRE_CUSTOMIZE_DIR
     fi
 
     filesystem_dev=$(map_disk0 $blockdev)
@@ -118,8 +126,6 @@ if [ "$CDINSTALL" = "no" ] ; then
     if [ "${INSTANCE_HV_serial_console}" = "True" ] ; then
         setup_console $TARGET
     fi
-
-    RUN_PARTS=`which run-parts`
 
     if [ -n "$RUN_PARTS" -a -n "$CUSTOMIZE_DIR" -a -d "$CUSTOMIZE_DIR" ]; then
       TARGET=$TARGET

--- a/defaults
+++ b/defaults
@@ -63,5 +63,10 @@
 # By default /etc/ganeti/instance-image/hooks
 # CUSTOMIZE_DIR="/etc/ganeti/instance-image/hooks"
 
+# PRE_CUSTOMIZE_DIR: a directory containing hooks to customize the installation before mounting.
+# The scripts are executed using run-parts
+# By default /etc/ganeti/instance-image/pre-hooks
+# PRE_CUSTOMIZE_DIR="/etc/ganeti/instance-image/pre-hooks"
+
 # IMAGE_DEBUG: turn on debugging output for the scripts
 # IMAGE_DEBUG=0

--- a/example/pre-hooks/resize_root_partition
+++ b/example/pre-hooks/resize_root_partition
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+# Copyright (C) 2014 GRNET S.A.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+
+set -e
+
+. ../hooks/common.sh
+
+debug set -x
+
+if [ "${IMAGE_TYPE}" = 'qemu' ]; then
+
+    if which partprobe >/dev/null 2>&1; then
+        PARTPROBE="`which partprobe`"
+    else
+        PARTPROBE="${BLOCKDEV_CMD} --rereadpt"
+    fi
+
+    # Set disk based on type of hypervisor
+    disk=""
+    if [ "${HYPERVISOR}" = "kvm" ] ; then
+        disk="vda"
+    else
+        disk="xda"
+    fi
+
+    # Get destination disk size in 512-byte sectors
+    device_size=`${BLOCKDEV_CMD} --getsz ${BLOCKDEV}`
+
+    # Get list of assigned partition sizes in table
+    sfdisk_sizes="`
+        # sfdisk -d seems to always output in 512-byte sectors regardless of -uX
+        # (using -uS here anyway in case someone else's sfdisk has a different default)
+        ${SFDISK} -L -uS -d ${BLOCKDEV} 2>/dev/null | \
+          sed -n -e '/^$/,$! b; /^$/ d; s:^.*size= *\([0-9]\+\),.*$:\1:; p' | \
+          tr '\n' ' '
+    `"
+
+    # Calculate total size used by partitions
+    used_size=0
+    for part_size in ${sfdisk_sizes}; do
+        used_size=`expr ${used_size} + ${part_size}`
+    done
+
+    # Abort if device too small
+    if [ ${device_size} -lt ${used_size} ]; then
+        printf 'Device size (%d sectors) is less than size used by partitions (%d sectors). Aborting.\n' "${device_size}" "${used_size}" >&2
+        cleanup
+        trap - EXIT
+        exit 1
+    fi
+
+    # If device too big
+    if [ ${device_size} -gt ${used_size} ]; then
+
+        # Get root (final) partition number
+        if [ "${SWAP}" = "yes" ] && [ -z "${KERNEL_PATH}" ] ; then
+            part_num=3
+        elif [ "${SWAP}" = "no" ] && [ -z "${KERNEL_PATH}" ] || [ "${SWAP}" = "yes" ] && [ -n "${KERNEL_PATH}" ] ; then
+            part_num=2
+        elif [ "${SWAP}" = "no" ] && [ -n "${KERNEL_PATH}" ] ; then
+            part_num=1
+        fi
+
+        # Expand final partition
+        ${SFDISK} -L -d ${BLOCKDEV} 2>/dev/null | \
+          {
+              counter=0
+              while IFS= read -r sfdiskline; do
+                  if [ 0 -eq $counter ]; then
+                      if [ -z "$sfdiskline" ]; then
+                          counter=1
+                      fi
+                      printf '%s\n' "$sfdiskline"
+                  else
+                      if [ $part_num -eq $counter ]; then
+                          printf '%s\n' "$sfdiskline" | \
+                              sed -e 's/size= *[0-9]\+,/size=,/'
+                      else
+                          printf '%s\n' "$sfdiskline"
+                      fi
+                      counter=`expr $counter + 1`
+                  fi
+              done
+          } | ${SFDISK} -L ${BLOCKDEV} 2>/dev/null
+
+        # Update awareness of new device size
+        new_device_size=`${BLOCKDEV_CMD} --getsz ${BLOCKDEV}`
+        new_device_table="$(
+            dmsetup table ${BLOCKDEV} | \
+                sed -e 's/^\([^ \t]\+[ \t]\+\)[^ \t]\+\([ \t]\)$/\1'"${new_device_size}"'\2/'
+        )"
+        trap 'set +e; cleanup' EXIT # not pretty, but the alternative would be too complex
+        dmsetup suspend ${BLOCKDEV}
+        dmsetup reload ${BLOCKDEV} --table "$new_device_table"
+        dmsetup resume ${BLOCKDEV}
+        trap cleanup EXIT # ..back to normal
+
+        filesystem_dev=$(map_disk0 ${BLOCKDEV})
+        CLEANUP+=("unmap_disk0 ${BLOCKDEV}")
+        ROOT_DEV=$(map_partition $filesystem_dev root)
+
+        # Expand filesystem on final partition
+        #TODO: equivalent commandlines for btrfs, xfs, zfs, ntfs, etc...
+        case `${BLKID} -p -u filesystem -s TYPE -o value ${ROOT_DEV}` in
+            ext2|ext3|ext4)
+                resize2fs -f ${ROOT_DEV} >/dev/null 2>&1
+                ;;
+        esac
+
+    fi
+fi
+
+cleanup
+trap - EXIT
+exit 0


### PR DESCRIPTION
This adds handling for a run-parts dir for pre-mount customisations, and includes a hook for resizing the root partition of an instance created from a qemu-image (other than windows images), so it uses all remaining space on the disk (for when the image size is smaller than the requested disk size). It also includes offline-resizing of the filesystem (I have added detection code and resize2fs for ext2/3/4, and it is trivial to swap in code for other FSes). This of course requires instances (other than windows) to have the same partition layout that is required from tarball and dump images. If that is too restrictive to apply to *all* qemu images, it would be straightforward to add a parameter (e.g. img_resize=true/false) to dictate whether to resize (and require a set partition layout) or not when using qemu-images (default off). Let me know if you want me to add that. Also, ideally dmsetup should be added into the autoconf machinery to handle dependency correctly rather than hard-coded in the hook (I just didn't have time today, if it is essential before merging this, I could rebase with that change when I find more time...).