### PR TITLE
cloud-init hook

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ overlaysdir=${sysconfdir}/ganeti/instance-image/overlays
 toolsdir=$(OS_DIR)/$(osname)/tools
 
 dist_os_SCRIPTS = ${srcdir}/create ${srcdir}/import ${srcdir}/export \
-	${srcdir}/rename
+	${srcdir}/rename ${srcdir}/cloud_init.rb
 dist_os_DATA = ${srcdir}/ganeti_api_version
 dist_config_DATA = ${srcdir}/variants.list
 os_DATA = common.sh

--- a/cloud_init.rb
+++ b/cloud_init.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+
+# Copyright (C) 2015 Oregon State University
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+require 'yaml'
+
+host = ENV['INSTANCE_NAME']
+user = ENV['CINIT_USER']
+ssh_key = ENV['CINIT_SSH_KEY']
+manage_resolv_conf = ENV['CINIT_MANAGE_RESOLV_CONF']
+name_servers = ENV['DNS_SERVERS']
+search_domains = ENV['DNS_SEARCH']
+domain = host.split('.').last(2).join('.')
+resolv_conf = nil
+
+if manage_resolv_conf == 'yes'
+  manage_conf = true
+  resolv_conf = {
+    'nameservers' => name_servers.split(' '),
+    'searchdomains' => search_domains.split(' '),
+    'domain' => domain,
+    'options' => {
+      'rotate' => true,
+      'timeout' => 1
+    }
+  }
+end
+
+init_modules =
+  %w(
+    migrator
+    bootcmd
+    write-files
+    growpart
+    resizefs
+    set_hostname
+    update_hostname
+    update_etc_hosts
+    resolv_conf
+    rsyslog
+    users-groups
+    ssh
+  )
+
+config = {
+  'hostname' => host.sub(/\..*$/, ''),
+  'fqdn' => host,
+  'instance-id' => host,
+  'disable_root' => 0,
+  'ssh_pwauth' => 0,
+  'datasource_list' => %w(None),
+  'manage-resolv-conf' => manage_conf,
+  'manage_resolv_conf' => manage_conf,
+  'cloud_init_modules' => init_modules,
+  'users' => [
+    'name' => user,
+    'primary-group' => user,
+    'groups' => %w(wheel adm systemd-journal),
+    'sudo' => ['ALL=(ALL) NOPASSWD:ALL'],
+    'shell' => '/bin/bash',
+    'lock_passwd' => true,
+    'ssh-authorized-keys' => [ssh_key]
+  ],
+  'groups' => [user],
+  'resolv_conf' => resolv_conf
+}
+
+puts config.to_yaml

--- a/cloud_init.rb
+++ b/cloud_init.rb
@@ -24,13 +24,13 @@ user = ENV['CINIT_USER']
 ssh_key = ENV['CINIT_SSH_KEY']
 disable_root = ENV['CINIT_DISABLE_ROOT'] == 'yes' ? 1 : 0
 ssh_pwauth = ENV['CINIT_SSH_PWAUTH'] == 'yes' ? 1 : 0
-manage_resolv_conf = ENV['CINIT_MANAGE_RESOLV_CONF']
+manage_resolv_conf = ENV['CINIT_MANAGE_RESOLV_CONF'] == 'yes' ? true : false
 name_servers = ENV['DNS_SERVERS']
 search_domains = ENV['DNS_SEARCH']
 domain = host.split('.').drop(1).join('.')
 resolv_conf = nil
 
-if manage_resolv_conf == 'yes'
+if manage_resolv_conf
   manage_conf = true
   resolv_conf = {
     'nameservers' => name_servers.split(' '),

--- a/cloud_init.rb
+++ b/cloud_init.rb
@@ -41,6 +41,8 @@ if manage_resolv_conf
       'timeout' => 1
     }
   }
+else
+  manage_conf = false
 end
 
 init_modules =

--- a/cloud_init.rb
+++ b/cloud_init.rb
@@ -25,7 +25,7 @@ ssh_key = ENV['CINIT_SSH_KEY']
 manage_resolv_conf = ENV['CINIT_MANAGE_RESOLV_CONF']
 name_servers = ENV['DNS_SERVERS']
 search_domains = ENV['DNS_SEARCH']
-domain = host.split('.').last(2).join('.')
+domain = host.split('.').drop(1).join('.')
 resolv_conf = nil
 
 if manage_resolv_conf == 'yes'

--- a/cloud_init.rb
+++ b/cloud_init.rb
@@ -19,7 +19,7 @@
 
 require 'yaml'
 
-host = ENV['INSTANCE_NAME']
+host = ENV['INSTANCE_NAME'] || ''
 user = ENV['CINIT_USER']
 ssh_key = ENV['CINIT_SSH_KEY']
 disable_root = ENV['CINIT_DISABLE_ROOT'] == 'yes' ? 1 : 0

--- a/cloud_init.rb
+++ b/cloud_init.rb
@@ -22,6 +22,8 @@ require 'yaml'
 host = ENV['INSTANCE_NAME']
 user = ENV['CINIT_USER']
 ssh_key = ENV['CINIT_SSH_KEY']
+disable_root = ENV['CINIT_DISABLE_ROOT'] == 'yes' ? 1 : 0
+ssh_pwauth = ENV['CINIT_SSH_PWAUTH'] == 'yes' ? 1 : 0
 manage_resolv_conf = ENV['CINIT_MANAGE_RESOLV_CONF']
 name_servers = ENV['DNS_SERVERS']
 search_domains = ENV['DNS_SEARCH']
@@ -61,8 +63,8 @@ config = {
   'hostname' => host.sub(/\..*$/, ''),
   'fqdn' => host,
   'instance-id' => host,
-  'disable_root' => 0,
-  'ssh_pwauth' => 0,
+  'disable_root' => disable_root,
+  'ssh_pwauth' => ssh_pwauth,
   'datasource_list' => %w(None),
   'manage-resolv-conf' => manage_conf,
   'manage_resolv_conf' => manage_conf,

--- a/cloud_init.rb
+++ b/cloud_init.rb
@@ -33,8 +33,8 @@ resolv_conf = nil
 if manage_resolv_conf
   manage_conf = true
   resolv_conf = {
-    'nameservers' => name_servers.split(' '),
-    'searchdomains' => search_domains.split(' '),
+    'nameservers' => name_servers.split,
+    'searchdomains' => search_domains.split,
     'domain' => domain,
     'options' => {
       'rotate' => true,

--- a/example/hooks/cloud-init
+++ b/example/hooks/cloud-init
@@ -40,6 +40,11 @@ export CINIT_MANAGE_RESOLV_CONF
 export DNS_SERVERS DNS_SEARCH
 
 # Write out config as a yaml file
-./cloud_init.rb > ${TARGET}/${cinit_cfg}
+if [ -d ${TARGET}/etc/cloud/cloud.cfg.d ] ; then
+  ./cloud_init.rb > ${TARGET}/${cinit_cfg}
+else
+  log_error "cloud-init is not installed"
+  exit 1
+fi
 
 exit 0

--- a/example/hooks/cloud-init
+++ b/example/hooks/cloud-init
@@ -35,8 +35,8 @@ if [ -z "${TARGET}" -o ! -d "${TARGET}" ] ; then
 fi
 
 # Need to export these out to the ruby script can read it
-export CINIT_USER CINIT_SSH_KEY
-export CINIT_MANAGE_RESOLV_CONF
+export CINIT_USER CINIT_SSH_KEY CINIT_SSH_PWAUTH
+export CINIT_MANAGE_RESOLV_CONF CINIT_DISABLE_ROOT
 export DNS_SERVERS DNS_SEARCH
 
 # Write out config as a yaml file

--- a/example/hooks/cloud-init
+++ b/example/hooks/cloud-init
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright (C) 2015 Oregon State University
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+# Copy files from an overlay directory into an instance. This assumes the same
+# filesystem structure as the system.
+
+set -e
+
+. common.sh
+
+# Ganeti specific NoCloud cloud-init config
+cinit_cfg="/etc/cloud/cloud.cfg.d/99_ganeti.cfg"
+
+debug set -x
+
+if [ -z "${TARGET}" -o ! -d "${TARGET}" ] ; then
+    log_error "Missing target directory"
+    exit 1
+fi
+
+# Need to export these out to the ruby script can read it
+export CINIT_USER CINIT_SSH_KEY
+export CINIT_MANAGE_RESOLV_CONF
+export DNS_SERVERS DNS_SEARCH
+
+# Write out config as a yaml file
+./cloud_init.rb > ${TARGET}/${cinit_cfg}
+
+exit 0

--- a/test/scripts/cloudinit.sh
+++ b/test/scripts/cloudinit.sh
@@ -1,0 +1,8 @@
+export INSTANCE_NAME=foo.bar.example.org
+export CINIT_USER=foobar
+export CINIT_MANAGE_RESOLV_CONF="yes"
+export DNS_SERVERS="192.168.1.1 192.168.1.2"
+export DNS_SEARCH="example.org example.bak"
+export CINIT_DISABLE_ROOT="yes"
+export CINIT_SSH_PWAUTH="no"
+./cloud_init.rb


### PR DESCRIPTION
This utilizes and requires cloud-init to be installed and enabled on an example.
This pulls several bash variables to generate a NoCloud cloud-init config. On
boot, cloud-init will read the config and set the hostname, user/group, ssh key
and dns settings for the instance. In addition it will grow the partition and
rootfs if those tools are installed and setup properly.

This hook is still a work in progress, but this is the first iteration of it.