### PR TITLE
add support for BLOCKEXPORT to export/import using qemu-img

### DIFF
--- a/common.sh.in
+++ b/common.sh.in
@@ -435,6 +435,7 @@ fi
 : ${IMAGE_NAME:=""}
 : ${IMAGE_TYPE:="dump"}
 : ${NOMOUNT:="no"}
+: ${BLOCKEXPORT:="no"}
 : ${ARCH:=""}
 : ${CUSTOMIZE_DIR:="@sysconfdir@/ganeti/instance-image/hooks"}
 : ${VARIANTS_DIR:="@sysconfdir@/ganeti/instance-image/variants"}

--- a/export
+++ b/export
@@ -31,7 +31,7 @@ if [ ! -b $blockdev ]; then
     CLEANUP+=("$LOSETUP -d $blockdev")
 fi
 
-if [ ! "${NOMOUNT}" = "yes" ] ; then
+if [ ! "${NOMOUNT}" = "yes" ] && [ ! "${BLOCKEXPORT}" = "yes" ] ; then
     filesystem_dev=$(map_disk0 $blockdev)
     CLEANUP+=("unmap_disk0 $blockdev")
     root_dev=$(map_partition $filesystem_dev root)
@@ -41,7 +41,7 @@ fi
 TARGET=`mktemp -d --tmpdir=${EXPORT_DIR}` || exit 1
 CLEANUP+=("rmdir $TARGET")
 
-if [ "${NOMOUNT}" = "yes" ] ; then
+if [ "${NOMOUNT}" = "yes" ] || [ "${BLOCKEXPORT}" = "yes" ] ; then
     # convert block device to qcow2 image to support OS's like Windows. Use
     # qcow2 to conserve on space.
     $QEMU_IMG convert $blockdev -O qcow2 ${TARGET}/disk.img

--- a/import
+++ b/import
@@ -36,7 +36,7 @@ CLEANUP+=("rmdir $TARGET")
 DUMPDIR=`mktemp -d` || exit 1
 CLEANUP+=("rm -rf $DUMPDIR")
 
-if [ ! "${NOMOUNT}" = "yes" ] ; then
+if [ ! "${NOMOUNT}" = "yes" ] && [ ! "${BLOCKEXPORT}" = "yes" ] ; then
     format_disk0 $blockdev
     filesystem_dev=$(map_disk0 $blockdev)
     CLEANUP+=("unmap_disk0 $blockdev")
@@ -55,7 +55,7 @@ fi
 # import dumps from tar file
 ( cd $DUMPDIR; tar -xf - )
 
-if [ "${NOMOUNT}" = "yes" ] ; then
+if [ "${NOMOUNT}" = "yes" ] || [ "${BLOCKEXPORT}" = "yes" ] ; then
     ( $QEMU_IMG convert ${DUMPDIR}/disk.img -O host_device ${blockdev} )
 else
     # clean up any previous restore runs


### PR DESCRIPTION
This allows the use of `qemu-img` to do exports and imports without the added baggage that using `$NOMOUNT` brings.