### PR TITLE
Tarball compress

### DIFF
--- a/create
+++ b/create
@@ -25,7 +25,30 @@ debug set -x
 
 case "$IMAGE_TYPE" in
   tarball)
-    IMG_EXT=".tar.gz"
+    case $IMAGE_TARBALL_COMPRESS in
+        none)
+          TARBALL_EXTENSION=".tar"
+          ;;
+        gzip|pigz)
+          TARBALL_EXTENSION=".tar.gz"
+          ;;
+        bzip2|pbzip2|lbzip2)
+          TARBALL_EXTENSION=".tar.bz2"
+          ;;
+        lzop)
+          TARBALL_EXTENSION=".tar.lzo"
+          ;;
+        xz)
+          TARBALL_EXTENSION=".tar.xz"
+          ;;
+        p7zip)
+          TARBALL_EXTENSION=".tar.7z"
+          ;;
+        *)
+          log_error "$IMAGE_TARBALL_COMPRESS as tarball compressor is not supported"
+          exit 1
+          ;;
+    esac
     ;;
   qemu)
     IMG_EXT=".img"
@@ -134,7 +157,7 @@ if [ "$CDINSTALL" = "no" ] ; then
 
     if [ "${IMAGE_TYPE}" = "tarball" ] ; then
         # unpack image
-        tar pzxf $IMAGE_FILE -C $TARGET
+        tar -I"$IMAGE_TARBALL_COMPRESS" -pxf $IMAGE_FILE -C $TARGET
     elif [ "${IMAGE_TYPE}" = "dump" ] ; then
         root_dump="${IMAGE_FILE}"
         ( cd ${TARGET}; restore -r -y -f ${root_dump} > /dev/null )

--- a/create
+++ b/create
@@ -25,27 +25,27 @@ debug set -x
 
 case "$IMAGE_TYPE" in
   tarball)
-    case $IMAGE_TARBALL_COMPRESS in
+    case $TARBALL_COMPRESS in
         none)
-          TARBALL_EXTENSION=".tar"
+          IMG_EXT=".tar"
           ;;
         gzip|pigz)
-          TARBALL_EXTENSION=".tar.gz"
+          IMG_EXT=".tar.gz"
           ;;
         bzip2|pbzip2|lbzip2)
-          TARBALL_EXTENSION=".tar.bz2"
+          IMG_EXT=".tar.bz2"
           ;;
         lzop)
-          TARBALL_EXTENSION=".tar.lzo"
+          IMG_EXT=".tar.lzo"
           ;;
         xz)
-          TARBALL_EXTENSION=".tar.xz"
+          IMG_EXT=".tar.xz"
           ;;
         p7zip)
-          TARBALL_EXTENSION=".tar.7z"
+          IMG_EXT=".tar.7z"
           ;;
         *)
-          log_error "$IMAGE_TARBALL_COMPRESS as tarball compressor is not supported"
+          log_error "$TARBALL_COMPRESS as tarball compressor is not supported"
           exit 1
           ;;
     esac
@@ -157,7 +157,7 @@ if [ "$CDINSTALL" = "no" ] ; then
 
     if [ "${IMAGE_TYPE}" = "tarball" ] ; then
         # unpack image
-        tar -I"$IMAGE_TARBALL_COMPRESS" -pxf $IMAGE_FILE -C $TARGET
+        tar -I"$TARBALL_COMPRESS" -pxf $IMAGE_FILE -C $TARGET
     elif [ "${IMAGE_TYPE}" = "dump" ] ; then
         root_dump="${IMAGE_FILE}"
         ( cd ${TARGET}; restore -r -y -f ${root_dump} > /dev/null )

--- a/defaults
+++ b/defaults
@@ -40,6 +40,13 @@
 # ( default is @localstatedir@/cache/ganeti-instance-image )
 # IMAGE_DIR=""
 
+# IMAGE_TARBALL_COMPRESS: compress program use to compress tar file.
+# It must accept the -d option, for decompression.
+# The argument can contain command line options.
+# Use either none, gzip, pigz, bzip2, pzip2, lbzip2, lzop, xz, p7zip
+# (default is gzip)
+# IMAGE_TARBALL_COMPRESS="gzip"
+
 # NOMOUNT: Do not try to mount volume (if it is not a linux partition). Accepts
 # either 'yes' or 'no'. This option is useful for installing Windows images for
 # example. ( default is no )

--- a/defaults
+++ b/defaults
@@ -40,12 +40,12 @@
 # ( default is @localstatedir@/cache/ganeti-instance-image )
 # IMAGE_DIR=""
 
-# IMAGE_TARBALL_COMPRESS: compress program use to compress tar file.
+# TARBALL_COMPRESS: compress program use to compress tar file.
 # It must accept the -d option, for decompression.
 # The argument can contain command line options.
 # Use either none, gzip, pigz, bzip2, pzip2, lbzip2, lzop, xz, p7zip
 # (default is gzip)
-# IMAGE_TARBALL_COMPRESS="gzip"
+# TARBALL_COMPRESS="gzip"
 
 # NOMOUNT: Do not try to mount volume (if it is not a linux partition). Accepts
 # either 'yes' or 'no'. This option is useful for installing Windows images for


### PR DESCRIPTION
Adding a TARBALL_COMPRESS variable to image definition.
This permit to use different compressor program with tarball as parallel version of bzip2 that permit to compress really more quickly depending on cpu threads available.
Extension of tarball is set accordingly to find tarball image.