### PR TITLE
bug fix: can't create instance if swap=no and disk size is < memory

### DIFF
--- a/create
+++ b/create
@@ -80,14 +80,17 @@ if [ "$CDINSTALL" = "no" ] ; then
 
     DISK_SIZE="$(expr `blockdev --getsize64 $blockdev` / 1048576)"
 
-    if [ "${SWAP}" = "yes" ] && [ -z "$SWAP_SIZE" ] ; then
-        log_error "SWAP_SIZE not set however SWAP is enabled"
-        exit 1
-    elif [ "${SWAP_SIZE}" -gt "${DISK_SIZE}" ] ; then
-        log_error "SWAP_SIZE larger than system disk size: "
-        log_error "  ${SWAP_SIZE}MB swap > ${DISK_SIZE}MB system disk"
-        exit 1
+    if [ "${SWAP}" = "yes" ] ; then
+        if [ -z "$SWAP_SIZE" ] ; then
+            log_error "SWAP_SIZE not set however SWAP is enabled"
+            exit 1
+        elif [ "${SWAP_SIZE}" -gt "${DISK_SIZE}" ] ; then
+            log_error "SWAP_SIZE larger than system disk size: "
+            log_error "  ${SWAP_SIZE}MB swap > ${DISK_SIZE}MB system disk"
+            exit 1
+        fi
     fi
+
 
     if [ ! -f "$IMAGE_FILE" ] ; then
       log_error "Can't find image file: $IMAGE_FILE"

--- a/create
+++ b/create
@@ -91,7 +91,6 @@ if [ "$CDINSTALL" = "no" ] ; then
         fi
     fi
 
-
     if [ ! -f "$IMAGE_FILE" ] ; then
       log_error "Can't find image file: $IMAGE_FILE"
       exit 1


### PR DESCRIPTION
Fix a really annoying bug:
If you don't use SWAP with SWAP=no, you can't create instance with disk size < memory size
